### PR TITLE
refactor: separate library from role; use plugin instead

### DIFF
--- a/collections/general/galaxy.yml
+++ b/collections/general/galaxy.yml
@@ -1,14 +1,15 @@
 namespace: daeuniverse
 name: general
-version: 1.2.1
+version: 1.3.6
 readme: README.md
 authors:
-  - Kevin Yu <kevinyu211@yahoo.com>
+  - kev (@yqlbu)
 description: ansible role for server general operations
 license_file: 'LICENSE'
 tags:
   - daeuniverse
   - general
+  - collection
 dependencies: {}
 repository: http://github.com/daeuniverse/galaxy-collections
 documentation: https://github.com/daeuniverse/galaxy-collections/tree/master/collections/general

--- a/collections/general/plugins/modules/github_workflow_run.py
+++ b/collections/general/plugins/modules/github_workflow_run.py
@@ -4,6 +4,42 @@ from ansible.module_utils.basic import AnsibleModule
 from urllib import request
 import json
 
+DOCUMENTATION = """
+---
+module: daeuniverse.general.github_workflow_run
+short_description: A custom Ansible module to fetch statistics accross GitHub workflow runs in @daeuniverse
+description:
+  - This module allows you to interact with GitHub workflow runs in @daeuniverse
+version_added: "1.0.0"
+author:
+  - kev (@yqlbu)
+tags:
+  - daeuniverse
+  - general
+  - module
+options:
+  owner:
+    description:
+      - The owner of the repo
+    required: true
+  repo:
+    description:
+      - The repo name
+    required: true
+  build_type:
+    description:
+      - The workflow build type
+    required: true
+"""
+
+EXAMPLES = """
+- name: Ensure a GitHub workflow run is present
+  daeuniverse.general.github_workflow_run:
+    owner: "daeuniverse"
+    repo: "dae"
+    build_type: "pr-build"
+"""
+
 
 class Module:
     def __init__(self, repo_owner: str, repo_name: str) -> None:

--- a/collections/general/roles/update/meta/main.yml
+++ b/collections/general/roles/update/meta/main.yml
@@ -1,16 +1,14 @@
 ---
-dependencies: []
-
 galaxy_info:
   authors:
     - kev (@yqlbu)
-  description: ansible collection for general operations
+  description: ansible role to update @daeuniverse/dae,@daeuniverse/daed
   min_ansible_version: "2.8"
   license: "MIT"
   tags:
     - daeuniverse
     - general
-    - collection
+    - role
   platforms:
     - name: GenericLinux
       versions:

--- a/collections/general/roles/update/tasks/update.yml
+++ b/collections/general/roles/update/tasks/update.yml
@@ -2,7 +2,7 @@
 - name: Fetch latest run_id from the given build_type
   block:
     - name: Fetch latest run_id from the given build_type
-      github_workflow_run:
+      daeuniverse.general.github_workflow_run:
         owner: "{{ owner }}"
         repo: "{{ app }}"
         build_type: "{{ build_type }}"


### PR DESCRIPTION
## Summary

Fix not being able to access the built-in module from the role. Define the module at the collection level instead.